### PR TITLE
Added socket close fix

### DIFF
--- a/model/quic-socket-base.cc
+++ b/model/quic-socket-base.cc
@@ -955,6 +955,8 @@ QuicSocketBase::SendPendingData (bool withAck)
         {
           m_drainingPeriodEvent.Cancel ();
           SendConnectionClosePacket (0, "Scheduled connection close - no error");
+          NS_LOG_LOGIC (this << " Close Schedule DoClose at time " << Simulator::Now ().GetSeconds () << " to expire at time " << (Simulator::Now () + m_drainingPeriodTimeout.Get ()).GetSeconds ());
+          m_drainingPeriodEvent = Simulator::Schedule (m_drainingPeriodTimeout, &QuicSocketBase::DoClose, this);
         }
       NS_LOG_INFO ("Nothing to send");
       return false;
@@ -1619,14 +1621,10 @@ QuicSocketBase::Close (void)
       else
         {
           m_drainingPeriodEvent.Cancel ();
+          NS_LOG_LOGIC (this << " Close Schedule DoClose at time " << Simulator::Now ().GetSeconds () << " to expire at time " << (Simulator::Now () + m_drainingPeriodTimeout.Get ()).GetSeconds ());
+          m_drainingPeriodEvent = Simulator::Schedule (m_drainingPeriodTimeout, &QuicSocketBase::DoClose, this);
           SendConnectionClosePacket (0, "Scheduled connection close - no error");
         }
-      NS_LOG_LOGIC (
-        this << " Close Schedule DoClose at time " << Simulator::Now ().GetSeconds () << " to expire at time " << (Simulator::Now () + m_drainingPeriodTimeout.Get ()).GetSeconds ());
-      m_drainingPeriodEvent = Simulator::Schedule (m_drainingPeriodTimeout,
-                                                   &QuicSocketBase::DoClose,
-                                                   this);
-      SendConnectionClosePacket (0, "Scheduled connection close - no error");
     }
   else if (m_idleTimeoutEvent.IsExpired () and m_socketState != CLOSING
            and m_socketState != IDLE and m_socketState != LISTENING) //Connection Close due to Idle Period termination

--- a/model/quic-socket-base.h
+++ b/model/quic-socket-base.h
@@ -724,6 +724,8 @@ protected:
   TracedValue<Time> m_drainingPeriodTimeout;  //!< Draining Period timeout
   EventId m_sendAckEvent;                     //!< Send ACK timeout event
   EventId m_delAckEvent;                      //!< Delayed ACK timeout event
+  bool m_flushOnClose;                        //!< Control behavior on connection close
+  bool m_closeOnEmpty;                        //!< True if the socket will close after sending the buffered packets
 
   // Congestion Control
   Ptr<QuicSocketState> m_tcb;                     //!< Congestion control informations


### PR DESCRIPTION
The behavior of the socket on close was undefined, and if the application closed it without flushing the packet buffer first (eg, BulkSendApplication) the simulation entered an infinite loop. This fix introduces the FlushOnClose attribute: if it is set to false (default), the socket will discard any buffered packets when the application calls the Close() method, while if it is set to true, the socket will refuse any more data to send but wait until the currently outstanding data are delivered to send a CLOSE_CONNECTION frame.