### PR TITLE
Don't abort simulation in case of buffer insertion failure.

### DIFF
--- a/model/quic-stream-base.cc
+++ b/model/quic-stream-base.cc
@@ -484,10 +484,12 @@ QuicStreamBase::Recv (Ptr<Packet> frame, const QuicSubheader& sub, Address &addr
           NS_LOG_INFO ("Buffering unordered received frame - offset " << m_recvSize << ", frame offset " << sub.GetOffset ());
           if (!m_rxBuffer->Add (frame, sub) && frame->GetSize () > 0)
             {
-              // Insert failed: No data or RX buffer full
-              NS_LOG_INFO ("Dropping packet due to full RX buffer");
-              // Abort simulation!
-              NS_ABORT_MSG ("Aborting Connection");
+              // Insert failed: No or duplicate data, or RX buffer full
+              NS_LOG_WARN ("Dropping packet as it could not be inserted in RX buffer");
+              if (frame->GetSize() > m_rxBuffer->Available()) {
+                  // Abort connection if indeed buffer is full
+                  m_quicl5->SignalAbortConnection (QuicSubheader::TransportErrorCodes_t::NO_ERROR,                                     "Aborting connection due to full RX buffer");
+              }
             }
         }
 

--- a/model/quic-stream-base.cc
+++ b/model/quic-stream-base.cc
@@ -488,7 +488,7 @@ QuicStreamBase::Recv (Ptr<Packet> frame, const QuicSubheader& sub, Address &addr
               NS_LOG_WARN ("Dropping packet as it could not be inserted in RX buffer");
               if (frame->GetSize() > m_rxBuffer->Available()) {
                   // Abort connection if indeed buffer is full
-                  m_quicl5->SignalAbortConnection (QuicSubheader::TransportErrorCodes_t::NO_ERROR,                                     "Aborting connection due to full RX buffer");
+                  m_quicl5->SignalAbortConnection (QuicSubheader::TransportErrorCodes_t::NO_ERROR, "Aborting connection due to full RX buffer");
               }
             }
         }


### PR DESCRIPTION
This PR fixes an issue in which a duplicate received packet would result in the entire simulation being aborted. See https://github.com/signetlabdei/quic-ns-3/issues/16 for more information. 

While I'm not entirely sure what would be the best way to handle a packet that could now be inserted into the RX buffer, it should not result in aborting the entire simulation. As I suspect that the abort was put there for a reason, I now signal to abort the connection if there is indeed no space left in the RX buffer.