### PR TITLE
Fix 'comparison of integer with different signedness' error.

### DIFF
--- a/model/quic-congestion-ops.cc
+++ b/model/quic-congestion-ops.cc
@@ -231,7 +231,7 @@ QuicCongestionOps::OnPacketAckedCC (Ptr<TcpSocketState> tcb,
     {
       NS_LOG_LOGIC ("In congestion avoidance");
       // Congestion Avoidance.
-      if (tcbd->m_cWnd > 0) {
+      if (tcbd->m_cWnd > (uint32_t) 0) {
           tcbd->m_cWnd += tcbd->m_segmentSize * ackedPacket->m_packet->GetSize ()
               / tcbd->m_cWnd;
       } else {


### PR DESCRIPTION
As I just realised when building on a Linux machine, my previous PR https://github.com/signetlabdei/quic/pull/12 introduced a 'comparison of integer expressions of different signedness' warning that some compilers may interpret as an error. 

This PR should fix that. 