### PR TITLE
Update to ns-3.37

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please use this [issue tracker](https://github.com/signetlabdei/quic-ns-3/issues
 ### Prerequisites ###
 
 To run simulations using this module, you will need to install ns-3, clone
-this repository inside the `src` directory, copy the QUIC applications from the quic-applications folder, and patch the `wscript` file of the applications module. 
+this repository inside the `src` directory, copy the QUIC applications from the quic-applications folder, and patch the `wscript` file of the applications module.
 Required dependencies include git and a build environment.
 
 #### Installing dependencies ####
@@ -38,42 +38,43 @@ git clone https://github.com/signetlabdei/quic quic
 Thirdly, copy the QUIC applications and helpers to the applications module
 
 ```bash
-cp src/quic/quic-applications/model/* src/applications/model/
-cp src/quic/quic-applications/helper/* src/applications/helper/
+cp quic/quic-applications/model/* applications/model/
+cp quic/quic-applications/helper/* applications/helper/
 ```
 
-Finally, edit the `wscript` file of the applications module and add
-
-```python
-        'model/quic-echo-client.h',
-        'model/quic-echo-server.h',
-        'model/quic-client.h',
-        'model/quic-server.h',
-        'helper/quic-echo-helper.h',
-        'helper/quic-client-server-helper.h'
-```
-to the `headers.source` list and
+Finally, edit the `CMakeLists.txt` file of the applications module and add
 
 ```python
-        'model/quic-echo-client.cc',
-        'model/quic-echo-server.cc',
-        'model/quic-client.cc',
-        'model/quic-server.cc',
-        'helper/quic-echo-helper.cc',
-        'helper/quic-client-server-helper.cc'
+        model/quic-echo-client.h
+        model/quic-echo-server.h
+        model/quic-client.h
+        model/quic-server.h
+        helper/quic-echo-helper.h
+        helper/quic-client-server-helper.h
 ```
-to the `module.source` list
+to the `HEADER_FILES` list and
+
+```python
+        model/quic-echo-client.cc
+        model/quic-echo-server.cc
+        model/quic-client.cc
+        model/quic-server.cc
+        helper/quic-echo-helper.cc
+        helper/quic-client-server-helper.cc
+```
+to the `SOURCE_FILES` list.
 ### Compilation ###
 
 Configure and build ns-3 from the `ns-3-dev` folder:
 
 ```bash
-./waf configure --enable-tests --enable-examples
-./waf build
+./ns3 configure --enable-tests --enable-examples
+./ns3 build
 ```
 
 If you are not interested in using the Python bindings, use
+
 ```bash
-./waf configure --enable-tests --enable-examples --disable-python
-./waf build
+./ns3 configure --enable-tests --enable-examples --disable-python
+./ns3 build
 ```

--- a/examples/quic-pacing.cc
+++ b/examples/quic-pacing.cc
@@ -22,12 +22,12 @@
 
 // This programs illustrates how QUIC pacing can be used and how user can set
 // pacing rate. The program gives information about each flow like transmitted
-// and received bytes (packets) and throughput of that flow. Currently, it is 
-// using QUIC NewReno-like but in future after having congestion control algorithms 
+// and received bytes (packets) and throughput of that flow. Currently, it is
+// using QUIC NewReno-like but in future after having congestion control algorithms
 // which can change pacing rate can be used.
-
-#include <string>
 #include <fstream>
+#include <string>
+
 #include "ns3/core-module.h"
 #include "ns3/point-to-point-module.h"
 #include "ns3/internet-module.h"
@@ -49,8 +49,18 @@ main (int argc, char *argv[])
   uint32_t maxBytes = 0;
   uint32_t QUICFlows = 1;
   bool isPacingEnabled = true;
-  std::string pacingRate = "4Gbps";
+  std::string pacingRate = "10Mbps";
   uint32_t maxPackets = 0;
+
+
+  // User may find it convenient to enable logging
+  Time::SetResolution (Time::NS);
+  LogComponentEnableAll (LOG_PREFIX_TIME);
+  LogComponentEnableAll (LOG_PREFIX_FUNC);
+  LogComponentEnableAll (LOG_PREFIX_NODE);
+  LogComponentEnable("QuicSocketBase", LOG_LEVEL_DEBUG);
+  LogComponentEnable("QuicPacingExample", LOG_LEVEL_INFO);
+
 
   CommandLine cmd;
   cmd.AddValue ("tracing", "Flag to enable/disable tracing", tracing);
@@ -75,10 +85,11 @@ main (int argc, char *argv[])
   NodeContainer nodes;
   nodes.Create (2);
 
+
   NS_LOG_INFO ("Create channels.");
   PointToPointHelper pointToPoint;
-  pointToPoint.SetDeviceAttribute ("DataRate", StringValue ("40Gbps"));
-  pointToPoint.SetChannelAttribute ("Delay", StringValue ("0.01ms"));
+  pointToPoint.SetDeviceAttribute ("DataRate", StringValue ("20Mbps"));
+  pointToPoint.SetChannelAttribute ("Delay", StringValue ("10ms"));
 
   NetDeviceContainer devices;
   devices = pointToPoint.Install (nodes);
@@ -111,9 +122,9 @@ main (int argc, char *argv[])
     }
 
   sinkApps.Start (Seconds (0.0));
-  sinkApps.Stop (Seconds (5));
+  sinkApps.Stop (Seconds (9));
   sourceApps.Start (Seconds (1));
-  sourceApps.Stop (Seconds (5));
+  sourceApps.Stop (Seconds (9));
 
   if (tracing)
     {
@@ -126,7 +137,7 @@ main (int argc, char *argv[])
   Ptr<FlowMonitor> monitor = flowmon.InstallAll ();
 
   NS_LOG_INFO ("Run Simulation.");
-  Simulator::Stop (Seconds (5));
+  Simulator::Stop (Seconds (10));
   Simulator::Run ();
 
   monitor->CheckForLostPackets ();

--- a/examples/quic-variants-comparison-bulksend.cc
+++ b/examples/quic-variants-comparison-bulksend.cc
@@ -16,7 +16,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
- * Authors of the original TCP example: 
+ * Authors of the original TCP example:
  * Justin P. Rohrer, Truc Anh N. Nguyen <annguyen@ittc.ku.edu>, Siddharth Gangadhar <siddharth@ittc.ku.edu>
  * James P.G. Sterbenz <jpgs@ittc.ku.edu>, director
  * ResiliNets Research Group  http://wiki.ittc.ku.edu/resilinets
@@ -28,10 +28,6 @@
  * under grant CNS-0626918 (Postmodern Internet Architecture),
  * NSF grant CNS-1050226 (Multilayer Network Resilience Analysis and Experimentation on GENI),
  * US Department of Defense (DoD), and ITTC at The University of Kansas.
- *
- * “TCP Westwood(+) Protocol Implementation in ns-3”
- * Siddharth Gangadhar, Trúc Anh Ngọc Nguyễn , Greeshma Umapathi, and James P.G. Sterbenz,
- * ICST SIMUTools Workshop on ns-3 (WNS3), Cannes, France, March 2013
  *
  * Adapted to QUIC by:
  *          Alvise De Biasio <alvise.debiasio@gmail.com>
@@ -149,7 +145,7 @@ int main (int argc, char *argv[])
   CommandLine cmd;
   cmd.AddValue ("transport_prot", "Transport protocol to use: TcpNewReno, "
                 "TcpHybla, TcpHighSpeed, TcpHtcp, TcpVegas, TcpScalable, TcpVeno, "
-                "TcpBic, TcpYeah, TcpIllinois, TcpWestwood, TcpWestwoodPlus, TcpLedbat ", transport_prot);
+                "TcpBic, TcpYeah, TcpIllinois, TcpLedbat", transport_prot);
   cmd.AddValue ("error_p", "Packet error rate", error_p);
   cmd.AddValue ("bandwidth", "Bottleneck bandwidth", bandwidth);
   cmd.AddValue ("delay", "Bottleneck delay", delay);
@@ -194,21 +190,11 @@ int main (int argc, char *argv[])
   Config::SetDefault ("ns3::QuicSocketBase::SocketSndBufSize", UintegerValue (1 << 21));
   Config::SetDefault ("ns3::QuicStreamBase::StreamSndBufSize", UintegerValue (1 << 21));
   Config::SetDefault ("ns3::QuicStreamBase::StreamRcvBufSize", UintegerValue (1 << 21));
- 
-  // Select congestion control variant
-  if (transport_prot.compare ("ns3::TcpWestwoodPlus") == 0)
-    { 
-      // TcpWestwoodPlus is not an actual TypeId name; we need TcpWestwood here
-      Config::SetDefault ("ns3::QuicL4Protocol::SocketType", TypeIdValue (TcpWestwood::GetTypeId ()));
-      // the default protocol type in ns3::TcpWestwood is WESTWOOD
-      Config::SetDefault ("ns3::TcpWestwood::ProtocolType", EnumValue (TcpWestwood::WESTWOODPLUS));
-    }
-  else
-    {
-      TypeId tcpTid;
-      NS_ABORT_MSG_UNLESS (TypeId::LookupByNameFailSafe (transport_prot, &tcpTid), "TypeId " << transport_prot << " not found");
-      Config::SetDefault ("ns3::QuicL4Protocol::SocketType", TypeIdValue (TypeId::LookupByName (transport_prot)));
-    }
+
+  TypeId tcpTid;
+  NS_ABORT_MSG_UNLESS (TypeId::LookupByNameFailSafe (transport_prot, &tcpTid), "TypeId " << transport_prot << " not found");
+  Config::SetDefault ("ns3::QuicL4Protocol::SocketType", TypeIdValue (TypeId::LookupByName (transport_prot)));
+
 
   // Create gateways, sources, and sinks
   NodeContainer gateways;
@@ -231,7 +217,7 @@ int main (int argc, char *argv[])
   BottleneckLink.SetDeviceAttribute ("DataRate", StringValue (bandwidth));
   BottleneckLink.SetChannelAttribute ("Delay", StringValue (delay));
   BottleneckLink.SetDeviceAttribute ("ReceiveErrorModel", PointerValue (&error_model));
-  
+
   PointToPointHelper AccessLink;
   AccessLink.SetDeviceAttribute ("DataRate", StringValue (access_bandwidth));
   AccessLink.SetChannelAttribute ("Delay", StringValue (access_delay));
@@ -295,7 +281,7 @@ int main (int argc, char *argv[])
       address.NewNetwork ();
       interfaces = address.Assign (devices);
       sink_interfaces.Add (interfaces.Get (1));
-      
+
       devices = BottleneckLink.Install (gateways.Get (0), gateways.Get (1));
       if (queue_disc_type.compare ("ns3::PfifoFastQueueDisc") == 0)
         {
@@ -318,7 +304,7 @@ int main (int argc, char *argv[])
 
   uint16_t port = 50000;
   Address sinkLocalAddress (InetSocketAddress (Ipv4Address::GetAny (), port));
-  
+
   ApplicationContainer clientApps;
   ApplicationContainer serverApps;
   // applications client and server
@@ -343,9 +329,9 @@ int main (int argc, char *argv[])
       auto n2 = sinks.Get (i);
       auto n1 = sources.Get (i);
       Time t = Seconds(2.100001);
-      Simulator::Schedule (t, &Traces, n2->GetId(), 
+      Simulator::Schedule (t, &Traces, n2->GetId(),
             "./server", ".txt");
-      Simulator::Schedule (t, &Traces, n1->GetId(), 
+      Simulator::Schedule (t, &Traces, n1->GetId(),
             "./client", ".txt");
     }
 

--- a/examples/quic-variants-comparison.cc
+++ b/examples/quic-variants-comparison.cc
@@ -16,7 +16,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
- * Authors of the original TCP example: 
+ * Authors of the original TCP example:
  * Justin P. Rohrer, Truc Anh N. Nguyen <annguyen@ittc.ku.edu>, Siddharth Gangadhar <siddharth@ittc.ku.edu>
  * James P.G. Sterbenz <jpgs@ittc.ku.edu>, director
  * ResiliNets Research Group  http://wiki.ittc.ku.edu/resilinets
@@ -28,10 +28,6 @@
  * under grant CNS-0626918 (Postmodern Internet Architecture),
  * NSF grant CNS-1050226 (Multilayer Network Resilience Analysis and Experimentation on GENI),
  * US Department of Defense (DoD), and ITTC at The University of Kansas.
- *
- * “TCP Westwood(+) Protocol Implementation in ns-3”
- * Siddharth Gangadhar, Trúc Anh Ngọc Nguyễn , Greeshma Umapathi, and James P.G. Sterbenz,
- * ICST SIMUTools Workshop on ns-3 (WNS3), Cannes, France, March 2013
  *
  * Adapted to QUIC by:
  *          Alvise De Biasio <alvise.debiasio@gmail.com>
@@ -150,7 +146,7 @@ int main (int argc, char *argv[])
   CommandLine cmd;
   cmd.AddValue ("transport_prot", "Transport protocol to use: TcpNewReno, "
                 "TcpHybla, TcpHighSpeed, TcpHtcp, TcpVegas, TcpScalable, TcpVeno, "
-                "TcpBic, TcpYeah, TcpIllinois, TcpWestwood, TcpWestwoodPlus, TcpLedbat ", transport_prot);
+                "TcpBic, TcpYeah, TcpIllinois, TcpLedbat ", transport_prot);
   cmd.AddValue ("error_p", "Packet error rate", error_p);
   cmd.AddValue ("bandwidth", "Bottleneck bandwidth", bandwidth);
   cmd.AddValue ("delay", "Bottleneck delay", delay);
@@ -194,21 +190,10 @@ int main (int argc, char *argv[])
   Config::SetDefault ("ns3::QuicSocketBase::SocketSndBufSize", UintegerValue (1 << 21));
   Config::SetDefault ("ns3::QuicStreamBase::StreamSndBufSize", UintegerValue (1 << 21));
   Config::SetDefault ("ns3::QuicStreamBase::StreamRcvBufSize", UintegerValue (1 << 21));
- 
-  // Select congestion control variant
-  if (transport_prot.compare ("ns3::TcpWestwoodPlus") == 0)
-    { 
-      // TcpWestwoodPlus is not an actual TypeId name; we need TcpWestwood here
-      Config::SetDefault ("ns3::QuicL4Protocol::SocketType", TypeIdValue (TcpWestwood::GetTypeId ()));
-      // the default protocol type in ns3::TcpWestwood is WESTWOOD
-      Config::SetDefault ("ns3::TcpWestwood::ProtocolType", EnumValue (TcpWestwood::WESTWOODPLUS));
-    }
-  else
-    {
-      TypeId tcpTid;
-      NS_ABORT_MSG_UNLESS (TypeId::LookupByNameFailSafe (transport_prot, &tcpTid), "TypeId " << transport_prot << " not found");
-      Config::SetDefault ("ns3::QuicL4Protocol::SocketType", TypeIdValue (TypeId::LookupByName (transport_prot)));
-    }
+
+  TypeId tcpTid;
+  NS_ABORT_MSG_UNLESS (TypeId::LookupByNameFailSafe (transport_prot, &tcpTid), "TypeId " << transport_prot << " not found");
+  Config::SetDefault ("ns3::QuicL4Protocol::SocketType", TypeIdValue (TypeId::LookupByName (transport_prot)));
 
 
   // Create gateways, sources, and sinks
@@ -232,7 +217,7 @@ int main (int argc, char *argv[])
   BottleneckLink.SetDeviceAttribute ("DataRate", StringValue (bandwidth));
   BottleneckLink.SetChannelAttribute ("Delay", StringValue (delay));
   BottleneckLink.SetDeviceAttribute ("ReceiveErrorModel", PointerValue (&error_model));
-  
+
   PointToPointHelper AccessLink;
   AccessLink.SetDeviceAttribute ("DataRate", StringValue (access_bandwidth));
   AccessLink.SetChannelAttribute ("Delay", StringValue (access_delay));
@@ -296,7 +281,7 @@ int main (int argc, char *argv[])
       address.NewNetwork ();
       interfaces = address.Assign (devices);
       sink_interfaces.Add (interfaces.Get (1));
-      
+
       devices = BottleneckLink.Install (gateways.Get (0), gateways.Get (1));
       if (queue_disc_type.compare ("ns3::PfifoFastQueueDisc") == 0)
         {
@@ -317,7 +302,7 @@ int main (int argc, char *argv[])
   NS_LOG_INFO ("Initialize Global Routing.");
   Ipv4GlobalRoutingHelper::PopulateRoutingTables ();
 
-  uint16_t port = 50000;  
+  uint16_t port = 50000;
   ApplicationContainer clientApps;
   ApplicationContainer serverApps;
   double interPacketInterval = 1000;
@@ -338,15 +323,15 @@ int main (int argc, char *argv[])
   serverApps.Start (Seconds (0.99));
   clientApps.Stop (Seconds (20.0));
   clientApps.Start (Seconds (2.0));
-  
+
   for (uint16_t i = 0; i < num_flows; i++)
     {
       auto n2 = sinks.Get (i);
       auto n1 = sources.Get (i);
       Time t = Seconds(2.100001);
-      Simulator::Schedule (t, &Traces, n2->GetId(), 
+      Simulator::Schedule (t, &Traces, n2->GetId(),
             "./server", ".txt");
-      Simulator::Schedule (t, &Traces, n1->GetId(), 
+      Simulator::Schedule (t, &Traces, n1->GetId(),
             "./client", ".txt");
     }
 

--- a/model/quic-bbr.cc
+++ b/model/quic-bbr.cc
@@ -1,6 +1,6 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
 /*
- * Copyright (c) 2018 NITK Surathkal, 
+ * Copyright (c) 2018 NITK Surathkal,
  * Copyright (c) 2020 SIGNET Lab, Department of Information Engineering, University of Padova
  *
  * This program is free software; you can redistribute it and/or modify
@@ -624,7 +624,7 @@ QuicBbr::CongestionStateSet (Ptr<TcpSocketState> tcb,
 {
   NS_LOG_FUNCTION (this << tcb << newState);
   Ptr<QuicSocketState> tcbd = dynamic_cast<QuicSocketState *> (&(*tcb));
-  NS_ASSERT_MSG (tcbd != 0, "tcb is not a QuicSocketState");
+  NS_ASSERT_MSG (tcbd, "tcb is not a QuicSocketState");
 
   if (newState == TcpSocketState::CA_OPEN && !m_isInitialized)
     {
@@ -666,7 +666,7 @@ QuicBbr::CwndEvent (Ptr<TcpSocketState> tcb,
 {
   NS_LOG_FUNCTION (this << tcb << event);
   Ptr<QuicSocketState> tcbd = dynamic_cast<QuicSocketState *> (&(*tcb));
-  NS_ASSERT_MSG (tcbd != 0, "tcb is not a QuicSocketState");
+  NS_ASSERT_MSG (tcbd, "tcb is not a QuicSocketState");
 
   if (event == TcpSocketState::CA_EVENT_COMPLETE_CWR)
     {
@@ -711,7 +711,7 @@ QuicBbr::OnPacketSent (Ptr<TcpSocketState> tcb, SequenceNumber32 packetNumber, b
 {
   NS_LOG_FUNCTION (this << packetNumber << isAckOnly);
   Ptr<QuicSocketState> tcbd = dynamic_cast<QuicSocketState *> (&(*tcb));
-  NS_ASSERT_MSG (tcbd != 0, "tcb is not a QuicSocketState");
+  NS_ASSERT_MSG (tcbd, "tcb is not a QuicSocketState");
 
   tcbd->m_timeOfLastSentPacket = Now ();
   tcbd->m_highTxMark = packetNumber;
@@ -725,7 +725,7 @@ QuicBbr::OnAckReceived (Ptr<TcpSocketState> tcb, QuicSubheader &ack,
   NS_LOG_FUNCTION (this);
 
   Ptr<QuicSocketState> tcbd = dynamic_cast<QuicSocketState *> (&(*tcb));
-  NS_ASSERT_MSG (tcbd != 0, "tcb is not a QuicSocketState");
+  NS_ASSERT_MSG (tcbd, "tcb is not a QuicSocketState");
 
   tcbd->m_largestAckedPacket = SequenceNumber32 (ack.GetLargestAcknowledged ());
 
@@ -767,7 +767,7 @@ QuicBbr::OnPacketsLost (Ptr<TcpSocketState> tcb, std::vector<Ptr<QuicSocketTxIte
 {
   NS_LOG_LOGIC (this);
   Ptr<QuicSocketState> tcbd = dynamic_cast<QuicSocketState *> (&(*tcb));
-  NS_ASSERT_MSG (tcbd != 0, "tcb is not a QuicSocketState");
+  NS_ASSERT_MSG (tcbd, "tcb is not a QuicSocketState");
 
   auto largestLostPacket = *(lostPackets.end () - 1);
 
@@ -787,7 +787,7 @@ QuicBbr::OnPacketAcked (Ptr<TcpSocketState> tcb, Ptr<QuicSocketTxItem> ackedPack
 {
   NS_LOG_FUNCTION (this);
   Ptr<QuicSocketState> tcbd = dynamic_cast<QuicSocketState*> (&(*tcb));
-  NS_ASSERT_MSG (tcbd != 0, "tcb is not a QuicSocketState");
+  NS_ASSERT_MSG (tcbd, "tcb is not a QuicSocketState");
 
   NS_LOG_LOGIC ("Handle possible RTO");
   // If a packet sent prior to RTO was acked, then the RTO  was spurious. Otherwise, inform congestion control.
@@ -806,7 +806,7 @@ QuicBbr::OnRetransmissionTimeoutVerified (Ptr<TcpSocketState> tcb)
 {
   NS_LOG_FUNCTION (this);
   Ptr<QuicSocketState> tcbd = dynamic_cast<QuicSocketState*> (&(*tcb));
-  NS_ASSERT_MSG (tcbd != 0, "tcb is not a QuicSocketState");
+  NS_ASSERT_MSG (tcbd, "tcb is not a QuicSocketState");
   NS_LOG_INFO ("Loss state");
   tcbd->m_congState = TcpSocketState::CA_LOSS;
   CongestionStateSet (tcbd, TcpSocketState::CA_LOSS);

--- a/model/quic-l4-protocol.cc
+++ b/model/quic-l4-protocol.cc
@@ -581,12 +581,12 @@ QuicL4Protocol::SetRecvCallback (Callback<void, Ptr<Packet>, const QuicHeader&, 
   for (it = m_quicUdpBindingList.begin (); it != m_quicUdpBindingList.end (); ++it)
     {
       Ptr<QuicUdpBinding> item = *it;
-      if (item->m_quicSocket == sock && item->m_budpSocket != 0)
+      if (item->m_quicSocket == sock && item->m_budpSocket)
         {
           item->m_budpSocket->SetRecvCallback (MakeCallback (&QuicL4Protocol::ForwardUp, this));
           break;
         }
-      else if (item->m_quicSocket == sock && item->m_budpSocket6 != 0)
+      else if (item->m_quicSocket == sock && item->m_budpSocket6)
         {
           item->m_budpSocket6->SetRecvCallback (MakeCallback (&QuicL4Protocol::ForwardUp, this));
           break;
@@ -604,9 +604,9 @@ QuicL4Protocol::NotifyNewAggregate ()
   NS_LOG_FUNCTION (this);
   Ptr<Node> node = this->GetObject<Node> ();
 
-  if (m_node == 0)
+  if (!m_node)
     {
-      if ((node != 0))
+      if (node)
         {
           this->SetNode (node);
           Ptr<QuicSocketFactory> quicFactory = CreateObject<QuicSocketFactory> ();
@@ -716,7 +716,7 @@ Ptr<Socket>
 QuicL4Protocol::CreateUdpSocket ()
 {
   NS_LOG_FUNCTION (this);
-  NS_ASSERT (m_node != 0);
+  NS_ASSERT (m_node);
 
   TypeId tid = TypeId::LookupByName ("ns3::UdpSocketFactory");
   Ptr<Socket> udpSocket = Socket::CreateSocket (m_node, tid);
@@ -728,7 +728,7 @@ Ptr<Socket>
 QuicL4Protocol::CreateUdpSocket6 ()
 {
   NS_LOG_FUNCTION (this);
-  NS_ASSERT (m_node != 0);
+  NS_ASSERT (m_node);
 
   TypeId tid = TypeId::LookupByName ("ns3::UdpSocketFactory");
   Ptr<Socket> udpSocket6 = Socket::CreateSocket (m_node, tid);
@@ -772,8 +772,8 @@ QuicL4Protocol::Receive (Ptr<Packet> packet,
                          Ipv6Header const &incomingIpHeader,
                          Ptr<Ipv6Interface> interface)
 {
-  NS_LOG_FUNCTION (this << packet << incomingIpHeader.GetSourceAddress () <<
-                   incomingIpHeader.GetDestinationAddress ());
+  NS_LOG_FUNCTION (this << packet << incomingIpHeader.GetSource () <<
+                   incomingIpHeader.GetDestination ());
   NS_FATAL_ERROR ("This call should not be used: QUIC packets need to go through a UDP socket");
   return IpL4Protocol::RX_OK;
 }

--- a/model/quic-l5-protocol.cc
+++ b/model/quic-l5-protocol.cc
@@ -198,12 +198,16 @@ QuicL5Protocol::DispatchSend (Ptr<Packet> data)
         {
           NS_LOG_INFO (
             "Sending data on stream " << (*jt)->GetStreamId ());
-          sentData = (*jt)->Send ((*it));
+          int streamSentData = (*jt)->Send ((*it));
+          if (streamSentData > 0)
+            {
+              sentData += streamSentData;
+            }
           ++it;
         }
     }
 
-  return sentData;
+  return (sentData > 0) ? sentData : -1;
 }
 
 int


### PR DESCRIPTION
Update the QUIC module to the ns-3.37 release. 

**List of changes:**

- Changed outdated calls to the Ipv6Header API
- Updated DispatchSend return value
- Updated README file to new version
- Updated scripts to remove TCP Westwood (unavailable in new release) from variants comparison
- Reduced capacity in quic-pacing script to speed up execution
